### PR TITLE
Basic gRPC proxying and service-based routing implemented

### DIFF
--- a/cmd/grpcbridge/main.go
+++ b/cmd/grpcbridge/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"net"
 	"os"
 	"os/signal"
 	"syscall"
@@ -11,8 +12,10 @@ import (
 
 	"github.com/renbou/grpcbridge"
 	"github.com/renbou/grpcbridge/grpcadapter"
+	"github.com/renbou/grpcbridge/grpcproxy"
 	"github.com/renbou/grpcbridge/internal/config"
 	"github.com/renbou/grpcbridge/reflection"
+	"github.com/renbou/grpcbridge/route"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 )
@@ -20,6 +23,22 @@ import (
 func main() {
 	if err := mainImpl(); err != nil {
 		os.Exit(1)
+	}
+}
+
+type aggregateWatcher struct {
+	watchers []reflection.DiscoveryWatcher
+}
+
+func (aw *aggregateWatcher) UpdateState(state *reflection.DiscoveryState) {
+	for _, w := range aw.watchers {
+		w.UpdateState(state)
+	}
+}
+
+func (aw *aggregateWatcher) ReportError(err error) {
+	for _, w := range aw.watchers {
+		w.ReportError(err)
 	}
 }
 
@@ -31,9 +50,7 @@ func (lw *loggingWatcher) UpdateState(state *reflection.DiscoveryState) {
 	lw.logger.Info("State updated", "state", state)
 }
 
-func (lw *loggingWatcher) ReportError(err error) {
-	lw.logger.Error("Error reported", "error", err)
-}
+func (lw *loggingWatcher) ReportError(err error) {}
 
 func mainImpl() error {
 	logger := grpcbridge.WrapPlainLogger(slog.New(slog.NewJSONHandler(
@@ -57,19 +74,40 @@ func mainImpl() error {
 		PollInterval: time.Second * 5,
 	})
 
+	router := route.NewServiceRouter(logger, connPool)
+
+	grpcProxyServer := grpcproxy.NewServer(logger, router)
+
 	for _, cfg := range cfg.Services {
 		_ = connPool.Build(context.Background(), cfg.Name, cfg.Target)
 
-		_, err = resolverBuilder.Build(cfg.Name, &loggingWatcher{logger: logger})
+		lw := &loggingWatcher{logger: logger}
+		rw := router.Watcher(cfg.Name)
+
+		_, err = resolverBuilder.Build(cfg.Name, &aggregateWatcher{watchers: []reflection.DiscoveryWatcher{lw, rw}})
 		if err != nil {
 			logger.Error("Failed to build resolver", "error", err)
 			return err
 		}
 	}
 
+	lis, err := net.Listen("tcp", ":11111")
+	if err != nil {
+		logger.Error("Failed to listen", "error", err)
+		return err
+	}
+
+	grpcServer := grpc.NewServer(grpc.UnknownServiceHandler(grpcProxyServer.Handler))
+
+	go func() {
+		_ = grpcServer.Serve(lis)
+	}()
+
 	shutdownCh := make(chan os.Signal, 1)
 	signal.Notify(shutdownCh, os.Interrupt, syscall.SIGTERM)
 	<-shutdownCh
+
+	grpcServer.Stop()
 
 	return nil
 }

--- a/grpcadapter/pool.go
+++ b/grpcadapter/pool.go
@@ -50,7 +50,12 @@ func (p *ClientConnPool) Get(name string) *ClientConn {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	return p.conns[name].cc
+	controller, ok := p.conns[name]
+	if !ok {
+		return nil
+	}
+
+	return controller.cc
 }
 
 func (p *ClientConnPool) remove(name string) {

--- a/grpcadapter/stream.go
+++ b/grpcadapter/stream.go
@@ -33,6 +33,11 @@ func (s *BiDiStream) Recv(ctx context.Context, msg proto.Message) error {
 	return s.withCtx(ctx, func() error { return s.stream.RecvMsg(msg) })
 }
 
+func (s *BiDiStream) CloseSend() {
+	// never returns an error, and we don't care about it anyway, just like with Close()
+	_ = s.stream.CloseSend()
+}
+
 func (s *BiDiStream) Close() {
 	s.closeFunc()
 }

--- a/grpcproxy/server.go
+++ b/grpcproxy/server.go
@@ -1,0 +1,135 @@
+package grpcproxy
+
+import (
+	"io"
+
+	"github.com/renbou/grpcbridge"
+	"github.com/renbou/grpcbridge/grpcadapter"
+	"github.com/renbou/grpcbridge/route"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/emptypb"
+)
+
+// Assertion to make sure that Handler can be registered as valid gRPC stream handler.
+var _ grpc.StreamHandler = (*Server)(nil).Handler
+
+type Server struct {
+	logger grpcbridge.Logger
+	router *route.ServiceRouter
+}
+
+func NewServer(logger grpcbridge.Logger, router *route.ServiceRouter) *Server {
+	return &Server{
+		logger: logger.WithComponent("grpcbridge.proxy.grpc"),
+		router: router,
+	}
+}
+
+func (s *Server) Handler(_ any, incoming grpc.ServerStream) error {
+	methodName, ok := grpc.Method(incoming.Context())
+	if !ok {
+		s.logger.Error("no method name in stream context, unable to route request")
+		return status.Errorf(codes.Internal, "no method name in stream context, unable to route request")
+	}
+
+	logger := s.logger.With("method", methodName)
+
+	conn, err := s.router.Route(methodName)
+	if err != nil {
+		return err
+	}
+
+	// TODO(renbou): timeouts for stream initiation and Recv/Sends
+	outgoing, err := conn.BiDiStream(incoming.Context(), methodName)
+	if err != nil {
+		return err
+	}
+
+	// Always clean up the outgoing stream by explicitly closing it.
+	defer outgoing.Close()
+
+	i2oErrCh := make(chan proxyingError, 1)
+	o2iErrCh := make(chan proxyingError, 1)
+
+	go func() {
+		i2oErrCh <- s.forwardIncomingToOutgoing(logger, incoming, outgoing)
+	}()
+
+	go func() {
+		o2iErrCh <- s.forwardOutgoingToIncoming(logger, outgoing, incoming)
+	}()
+
+	// Handle proxying errors and return them when needed,
+	// closing the outgoing stream without waiting for the other goroutine to complete.
+	// It will not deadlock thanks to the buffer of the channels,
+	// and is guaranteed to receive an error from operations on the outgoing channel.
+	for {
+		select {
+		case perr := <-i2oErrCh:
+			if perr.incomingErr == io.EOF || perr.outgoingErr == io.EOF {
+				// io.EOF can arrive either from incoming.RecvMsg or outgoing.Send,
+				// and in both cases we need to receive further responses via outgoing.Recv until it returns a proper error.
+				// For this to work properly, forward a CloseSend to outgoing, even though io.EOF from outgoing.Send might've already done so.
+				// Calling it here is safe since outgoing.Send isn't going to get called anymore anyway.
+				outgoing.CloseSend()
+			} else if perr.incomingErr != nil {
+				return perr.incomingErr
+			} else {
+				// perr.outgoingErr is guaranteed to be non-nil by forwardIncomingToOutgoing.
+				return perr.outgoingErr
+			}
+		case perr := <-o2iErrCh:
+			if perr.outgoingErr == io.EOF {
+				// io.EOF from outgoing.Recv means that the stream has been properly closed, forward this closure to the incoming stream.
+				return nil
+			} else if perr.incomingErr != nil {
+				return perr.incomingErr
+			} else {
+				// perr.outgoingErr is guaranteed to be non-nil by forwardOutgoingToIncoming.
+				return perr.outgoingErr
+			}
+		}
+	}
+}
+
+// proxyingError is a utility struct to distinguish errors received from incoming.RecvMsg/SendMsg and outgoing.Recv/Send calls.
+// This is mostly needed for properly handling io.EOF errors which might come from all sorts of calls.
+type proxyingError struct {
+	incomingErr error
+	outgoingErr error
+}
+
+func (s *Server) forwardIncomingToOutgoing(logger grpcbridge.Logger, incoming grpc.ServerStream, outgoing *grpcadapter.BiDiStream) proxyingError {
+	defer logger.Debug("ending forwarding incoming to outgoing")
+
+	for {
+		// Proto properly unmarshals any message into an empty one, keeping all the fields as protoimpl.UnknownFields.
+		msg := new(emptypb.Empty)
+
+		if err := incoming.RecvMsg(msg); err != nil {
+			return proxyingError{incomingErr: err}
+		}
+
+		if err := outgoing.Send(incoming.Context(), msg); err != nil {
+			return proxyingError{outgoingErr: err}
+		}
+	}
+}
+
+func (s *Server) forwardOutgoingToIncoming(logger grpcbridge.Logger, outgoing *grpcadapter.BiDiStream, incoming grpc.ServerStream) proxyingError {
+	defer logger.Debug("ending forwarding outgoing to incoming")
+
+	for {
+		msg := new(emptypb.Empty)
+
+		if err := outgoing.Recv(incoming.Context(), msg); err != nil {
+			return proxyingError{outgoingErr: err}
+		}
+
+		if err := incoming.SendMsg(msg); err != nil {
+			return proxyingError{incomingErr: err}
+		}
+	}
+}

--- a/reflection/resolver.go
+++ b/reflection/resolver.go
@@ -53,7 +53,7 @@ func (opts *ResolverOpts) WithDefaults() ResolverOpts {
 var DefaultResolverOpts = ResolverOpts{
 	PollInterval:   5 * time.Minute,
 	ReqTimeout:     10 * time.Second,
-	IgnorePrefixes: []string{},
+	IgnorePrefixes: nil,
 }
 
 type ResolverBuilder struct {

--- a/route/service_router.go
+++ b/route/service_router.go
@@ -1,0 +1,159 @@
+package route
+
+import (
+	"strings"
+	"sync"
+
+	"github.com/renbou/grpcbridge"
+	"github.com/renbou/grpcbridge/grpcadapter"
+	"github.com/renbou/grpcbridge/reflection"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+type serviceRoute struct {
+	name string
+	desc reflection.ServiceDesc
+}
+
+type ServiceRouter struct {
+	pool   *grpcadapter.ClientConnPool
+	logger grpcbridge.Logger
+
+	mu sync.Mutex // protects the routing info
+	// map from gRPC service name to its bridged name and gRPC description,
+	// used for actually routing requests
+	routes map[string]*serviceRoute
+	// map from bridged service name to its gRPC service names,
+	// used for keeping track of a service's routes and removing them from/adding them to the routing map when needed.
+	svcRoutes map[string][]string
+}
+
+func NewServiceRouter(logger grpcbridge.Logger, pool *grpcadapter.ClientConnPool) *ServiceRouter {
+	return &ServiceRouter{
+		pool:      pool,
+		logger:    logger.WithComponent("grpcbridge.route"),
+		routes:    make(map[string]*serviceRoute),
+		svcRoutes: make(map[string][]string),
+	}
+}
+
+func (sr *ServiceRouter) Route(path string) (*grpcadapter.ClientConn, error) {
+	sr.mu.Lock()
+	defer sr.mu.Unlock()
+
+	svc, _, ok := parseGRPCMethod(path)
+	if !ok {
+		return nil, status.Errorf(codes.NotFound, "no route for path of invalid gRPC format")
+	}
+
+	route, ok := sr.routes[svc]
+	if !ok {
+		return nil, status.Errorf(codes.NotFound, "no route for gRPC service %q", svc)
+	}
+
+	conn := sr.pool.Get(route.name)
+	if conn == nil {
+		return nil, status.Errorf(codes.Unavailable, "no connection to available in pool for target %q", route.name)
+	}
+
+	return conn, nil
+}
+
+func (sr *ServiceRouter) Watcher(name string) *ServiceRouterWatcher {
+	return &ServiceRouterWatcher{
+		sr:   sr,
+		name: name,
+	}
+}
+
+func (sr *ServiceRouter) updateRoutes(name string, state *reflection.DiscoveryState) {
+	sr.mu.Lock()
+	defer sr.mu.Unlock()
+
+	newSvcRoutes := make([]string, 0, len(state.Services))
+	presentSvcRoutes := make(map[string]struct{}, len(state.Services))
+
+	// Handle current routes
+	for _, svc := range state.Services {
+		// Add new routes
+		route, ok := sr.routes[string(svc.Name)]
+		if !ok {
+			sr.logger.Debug("adding route", "service", name, "route", svc.Name)
+
+			route = &serviceRoute{name: name}
+			sr.routes[string(svc.Name)] = route
+		} else if ok && route.name != name {
+			// Since this router has no way to distinguish which routes go where,
+			// it's better to avoid overwriting a route due to some accidental mistake by the user.
+			sr.logger.Warn("ServiceRouter encountered gRPC service route conflict, keeping previous route",
+				"route", svc.Name,
+				"previous_service", route.name,
+				"new_service", name,
+			)
+			continue
+		}
+
+		// Update the route description
+		route.desc = svc
+
+		// Mark route as present to avoid removing it
+		presentSvcRoutes[string(svc.Name)] = struct{}{}
+		newSvcRoutes = append(newSvcRoutes, string(svc.Name))
+	}
+
+	// Remove outdated routes
+	for _, route := range sr.svcRoutes[name] {
+		if _, ok := presentSvcRoutes[route]; !ok {
+			sr.logger.Debug("removing route", "service", name, "route", route)
+
+			delete(sr.routes, route)
+		}
+	}
+
+	sr.svcRoutes[name] = newSvcRoutes
+}
+
+func (sr *ServiceRouter) cleanRoutes(name string) {
+	sr.mu.Lock()
+	defer sr.mu.Unlock()
+
+	routes := sr.svcRoutes[name]
+
+	for _, route := range routes {
+		delete(sr.routes, route)
+	}
+
+	delete(sr.svcRoutes, name)
+}
+
+type ServiceRouterWatcher struct {
+	sr   *ServiceRouter
+	name string
+}
+
+func (srw *ServiceRouterWatcher) UpdateState(state *reflection.DiscoveryState) {
+	srw.sr.updateRoutes(srw.name, state)
+}
+
+func (srw *ServiceRouterWatcher) ReportError(error) {
+	// error ignored because it can't be meaningfully used with this type of routing,
+	// where the router can't tell which requests the error should be applied to,
+	// as all of the routing is done based on information from the discovery resolver.
+	// TODO(renbou): remove routes for this service if multiple errors are reported without state updates?
+}
+
+func (srw *ServiceRouterWatcher) Close() {
+	srw.sr.mu.Lock()
+	defer srw.sr.mu.Unlock()
+
+	srw.sr.cleanRoutes(srw.name)
+}
+
+func parseGRPCMethod(method string) (string, string, bool) {
+	if len(method) < 1 || method[0] != '/' {
+		return "", "", false
+	}
+
+	return strings.Cut(method[1:], "/")
+}

--- a/test/testapi/compose.yml
+++ b/test/testapi/compose.yml
@@ -1,12 +1,8 @@
 services:
   testapi:
-    image: testapi:latest
     build: .
+    environment:
+      LISTEN_ADDR: ":50051"
     ports:
       - "50051:50051"
-    restart: unless-stopped
-  testapi2:
-    image: testapi:latest
-    ports:
-      - "50052:50051"
     restart: unless-stopped


### PR DESCRIPTION
Currently tested all streaming endpoints of the Go-based testapi, next it is needed to write an additional API for testing that routing works properly. Currently all setup is done in `main` without proper setup/shutdown, later it should get placed in a separate module.